### PR TITLE
Use takari-plugin-testing for executing Maven from tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 # Ignore Gradle build output directory
 build
 .kotlin/
+
+# Used by takari-plugin-testing library used in MavenEndToEndFuncTest
+# unfortunately this path is hard coded here https://github.com/takari/takari-plugin-testing-project/blob/04312cdd308b284ed8dfa9655174abc2efcbfe20/takari-plugin-testing/src/main/java/io/takari/maven/testing/executor/junit/MavenVersionResolver.java#L97
+# and can therefore not be changed to be inside the build directory.
+target

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,8 +40,6 @@ dependencies {
         }
     }
 
-    testImplementation(libs.bundles.spock)
-    testImplementation(testFixtures(project))
     testFixturesImplementation(libs.junit4)
     testFixturesImplementation(libs.commonsLang)
 }
@@ -61,8 +59,20 @@ pluginPublishConventions {
     }
 }
 
+// Required to write localRepository property to src/test/resources/test.properties for takari-plugin-testing used in MavenEndToEndFuncTest
+tasks.processTestResources {
+    expand("localRepository" to project.layout.buildDirectory.dir("mavenLocal").get().asFile)
+}
+
 testing.suites.named<JvmTestSuite>("test") {
     useSpock()
+    dependencies {
+        implementation(libs.spock.core)
+        implementation(libs.spock.junit4)
+        implementation(libs.takariPluginTesting)
+        implementation(project.dependencies.testFixtures(project))
+        runtimeOnly(libs.junitVintageEngine)
+    }
 }
 
 testing.suites.register<JvmTestSuite>("testSamples") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,9 +15,7 @@ qdox = { module = "com.thoughtworks.qdox:qdox", version = { require = "2.0-M9", 
 spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }
 spock-junit4 = { module = "org.spockframework:spock-junit4", version.ref = "spock" }
 junit4 = { module = "junit:junit", version = "4.13.2" }
+junitVintageEngine = { module = "org.junit.vintage:junit-vintage-engine", version = "5.11.4" }
+takariPluginTesting = { module = "io.takari.maven.plugins:takari-plugin-integration-testing", version = "3.0.0" }
 commonsLang = { module = "org.apache.commons:commons-lang3", version = "3.17.0" }
 exemplar-sampleCheck = { module = "org.gradle.exemplar:samples-check", version = "1.0.2" }
-
-[bundles]
-mavenPluginTools-deps = ["mavenPluginTools-api", "mavenPluginTools-annotations", "mavenPluginTools-java", "mavenPluginTools-generators"]
-spock = ["spock-core", "spock-junit4"]

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,0 +1,3 @@
+# required for takari-plugin-testing used in MavenEndToEndFuncTest
+repository.0=<url>https://repo.maven.apache.org/maven2/</url>
+localRepository=${localRepository}


### PR DESCRIPTION
This replaces shelling out and calling mvn which required a Maven installation
to be present on the host running the test.

Fixes #284
